### PR TITLE
Add basic iOS CI workflow

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,20 @@
+name: iOS CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v3
+      - uses: xcodes-org/xcodes-action@v1
+        with:
+          xcode-version: '15.0'
+      - name: Build and test
+        run: |
+          xcodebuild -project RunTail/RunTail.xcodeproj -scheme RunTail \
+            -destination 'platform=iOS Simulator,name=iPhone 14' clean test | xcpretty

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🐾 RunTail – On Your Mark!
 
+![iOS CI](https://github.com/yourname/runtail-ios/actions/workflows/ios.yml/badge.svg)
+
 > **Create, share, and follow custom running routes — your personal running journey.**  
 > **나만의 러닝 루트를 만들고, 공유하고, 함께 달리는 커뮤니티 앱.**
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and test on macOS
- display CI status badge in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68445d19f3a083318e820b16a8c711cf