### PR TITLE
Add unit tests with mock auth

### DIFF
--- a/RunTail/RunTail/Services/FirebaseService.swift
+++ b/RunTail/RunTail/Services/FirebaseService.swift
@@ -11,26 +11,41 @@ import FirebaseAuth
 import FirebaseFirestore
 import MapKit
 
+protocol FirebaseAuthProtocol {
+    var currentUserEmail: String? { get }
+    var currentUserId: String? { get }
+    func signOut() throws
+}
+
+extension Auth: FirebaseAuthProtocol {
+    var currentUserEmail: String? { currentUser?.email }
+    var currentUserId: String? { currentUser?.uid }
+}
+
 class FirebaseService {
     static let shared = FirebaseService()
-    
-    private init() {}
+
+    private let auth: FirebaseAuthProtocol
+
+    init(auth: FirebaseAuthProtocol = Auth.auth()) {
+        self.auth = auth
+    }
     
     // MARK: - 인증 관련
     
     func logoutUser() -> Bool {
         do {
-            try Auth.auth().signOut()
+            try auth.signOut()
             return true
         } catch {
             print("로그아웃 오류: \(error.localizedDescription)")
             return false
         }
     }
-    
+
     func getCurrentUser() -> (id: String, email: String)? {
-        if let user = Auth.auth().currentUser {
-            return (id: user.uid, email: user.email ?? "")
+        if let id = auth.currentUserId, let email = auth.currentUserEmail {
+            return (id: id, email: email)
         }
         return nil
     }

--- a/RunTail/RunTail/ViewModel/MapViewModel.swift
+++ b/RunTail/RunTail/ViewModel/MapViewModel.swift
@@ -104,11 +104,16 @@ class MapViewModel: ObservableObject {
     )
     
     // MARK: - 생성자
-    init() {
-        if let user = Auth.auth().currentUser {
+    init(authProvider: FirebaseAuthProtocol? = nil, loadData: Bool = true) {
+        if let provider = authProvider {
+            userEmail = provider.currentUserEmail ?? ""
+            userId = provider.currentUserId ?? ""
+        } else if let user = Auth.auth().currentUser {
             userEmail = user.email ?? ""
             userId = user.uid
-            
+        }
+
+        if loadData && !userId.isEmpty {
             loadUserData()
             loadRecentRuns()
             loadMyCourses()

--- a/RunTail/RunTailTests/FirebaseServiceTests.swift
+++ b/RunTail/RunTailTests/FirebaseServiceTests.swift
@@ -1,0 +1,40 @@
+import Testing
+@testable import RunTail
+
+final class MockAuthService: FirebaseAuthProtocol {
+    var currentUserEmail: String?
+    var currentUserId: String?
+    var signOutCalled = false
+    var shouldThrow = false
+
+    func signOut() throws {
+        signOutCalled = true
+        if shouldThrow {
+            struct ErrorStub: Error {}
+            throw ErrorStub()
+        }
+    }
+}
+
+struct FirebaseServiceTests {
+    @Test func getCurrentUserNil() async throws {
+        let auth = MockAuthService()
+        let service = FirebaseService(auth: auth)
+        #expect(service.getCurrentUser() == nil)
+    }
+
+    @Test func logoutUserSuccess() async throws {
+        let auth = MockAuthService()
+        let service = FirebaseService(auth: auth)
+        #expect(service.logoutUser())
+        #expect(auth.signOutCalled)
+    }
+
+    @Test func logoutUserFailure() async throws {
+        let auth = MockAuthService()
+        auth.shouldThrow = true
+        let service = FirebaseService(auth: auth)
+        #expect(!service.logoutUser())
+        #expect(auth.signOutCalled)
+    }
+}

--- a/RunTail/RunTailTests/MapViewModelTests.swift
+++ b/RunTail/RunTailTests/MapViewModelTests.swift
@@ -1,0 +1,66 @@
+import Testing
+import CoreLocation
+@testable import RunTail
+
+final class MockAuth: FirebaseAuthProtocol {
+    var currentUserEmail: String?
+    var currentUserId: String?
+    var signOutCalled = false
+    var signOutError: Error?
+
+    func signOut() throws {
+        signOutCalled = true
+        if let error = signOutError { throw error }
+    }
+}
+
+struct MapViewModelTests {
+    @Test func startAndStopRun() async throws {
+        let auth = MockAuth()
+        auth.currentUserId = "user"
+        auth.currentUserEmail = "test@example.com"
+        let vm = MapViewModel(authProvider: auth, loadData: false)
+
+        vm.startRecording()
+        #expect(vm.isRecording)
+        #expect(!vm.isPaused)
+
+        vm.addLocationToRecording(coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0))
+        vm.addLocationToRecording(coordinate: CLLocationCoordinate2D(latitude: 0.001, longitude: 0.001))
+
+        var result: Bool? = nil
+        vm.stopRecording { success, _ in
+            result = success
+        }
+
+        #expect(result == true)
+        #expect(!vm.isRecording)
+        #expect(vm.showSaveAlert)
+    }
+
+    @Test func courseFollowingLogic() async throws {
+        let auth = MockAuth()
+        let vm = MapViewModel(authProvider: auth, loadData: false)
+
+        let coords = [
+            Coordinate(lat: 0, lng: 0, timestamp: 0),
+            Coordinate(lat: 0, lng: 0.001, timestamp: 1),
+            Coordinate(lat: 0, lng: 0.002, timestamp: 2)
+        ]
+        let course = Course(id: "c", title: "Test", distance: 200, coordinates: coords, createdAt: Date(), createdBy: "u", isPublic: true)
+
+        vm.startFollowingCourse(course)
+        #expect(vm.isFollowingCourse)
+        #expect(vm.nextWaypoint != nil)
+
+        vm.addLocationToRecordingWithCourseTracking(coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0.001))
+        #expect(vm.courseProgress > 0)
+        #expect(!vm.isOffCourse)
+
+        vm.updateCourseTracking(userLocation: CLLocationCoordinate2D(latitude: 10, longitude: 10))
+        #expect(vm.isOffCourse)
+
+        vm.stopFollowingCourse()
+        #expect(!vm.isFollowingCourse)
+    }
+}


### PR DESCRIPTION
## Summary
- enable dependency injection for `FirebaseService` and `MapViewModel`
- add tests for starting/stopping runs and course following
- add tests for FirebaseService using mock auth

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68445d17571c8331a6c723b83023ed63