### PR TITLE
Fix Auth import in ExploreCourseCard

### DIFF
--- a/RunTail/RunTail/Views/ExploreCourseCard.swift
+++ b/RunTail/RunTail/Views/ExploreCourseCard.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Firebase
+import FirebaseAuth
 
 // Card used in ExploreTabView course lists
 struct ExploreCourseCard: View {


### PR DESCRIPTION
## Summary
- import FirebaseAuth in ExploreCourseCard to fix missing `Auth` symbol

## Testing
- `xcodebuild test -scheme RunTail -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844609f6bc88331abbc09178d20872d