### PR TITLE
Implement adaptive colors for dark mode

### DIFF
--- a/RunTail/RunTail/Utils/ThemeManager.swift
+++ b/RunTail/RunTail/Utils/ThemeManager.swift
@@ -24,6 +24,16 @@ extension Color {
     static let rtCard = Color.white
     static let rtBackgroundDark = Color(red: 28/255, green: 28/255, blue: 35/255) // #1C1C23
     static let rtCardDark = Color(red: 38/255, green: 38/255, blue: 45/255) // #26262D
+
+    /// 다크 모드 지원을 위한 동적 배경 색상
+    static let rtBackgroundAdaptive = Color(UIColor {
+        $0.userInterfaceStyle == .dark ? UIColor(Color.rtBackgroundDark) : UIColor(Color.rtBackground)
+    })
+
+    /// 카드용 동적 배경 색상
+    static let rtCardAdaptive = Color(UIColor {
+        $0.userInterfaceStyle == .dark ? UIColor(Color.rtCardDark) : UIColor(Color.rtCard)
+    })
 }
 
 // MARK: - 그라데이션
@@ -137,7 +147,7 @@ struct RTCardView<Content: View>: View {
     var body: some View {
         content
             .padding(16)
-            .background(Color.rtCard)
+            .background(Color.rtCardAdaptive)
             .cornerRadius(16)
             .shadow(color: Color.black.opacity(0.08), radius: 8, x: 0, y: 3)
     }

--- a/RunTail/RunTail/Views/ActivityComponents.swift
+++ b/RunTail/RunTail/Views/ActivityComponents.swift
@@ -84,7 +84,7 @@ struct RunningHistoryItem: View {
                 }
             }
             .padding()
-            .background(Color.white)
+            .background(Color.rtCardAdaptive)
             .cornerRadius(16)
             .shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 2)
         }

--- a/RunTail/RunTail/Views/ActivityTabView.swift
+++ b/RunTail/RunTail/Views/ActivityTabView.swift
@@ -32,7 +32,7 @@ struct ActivityTabView: View {
                     // 월 선택 달력
                     calendarView
                         .padding(.horizontal)
-                        .background(Color.white)
+                        .background(Color.rtCardAdaptive)
                         .cornerRadius(16)
                         .shadow(color: Color.black.opacity(0.05), radius: 5, x: 0, y: 2)
                         .padding(.horizontal)
@@ -163,7 +163,7 @@ struct ActivityTabView: View {
             }
             .frame(maxWidth: .infinity)
             .padding()
-            .background(Color.white)
+            .background(Color.rtCardAdaptive)
             .cornerRadius(16)
             .shadow(color: Color.black.opacity(0.05), radius: 5, x: 0, y: 2)
             
@@ -188,7 +188,7 @@ struct ActivityTabView: View {
             }
             .frame(maxWidth: .infinity)
             .padding()
-            .background(Color.white)
+            .background(Color.rtCardAdaptive)
             .cornerRadius(16)
             .shadow(color: Color.black.opacity(0.05), radius: 5, x: 0, y: 2)
         }
@@ -235,7 +235,7 @@ struct ActivityTabView: View {
                 }
                 .padding(.vertical, 40)
                 .frame(maxWidth: .infinity)
-                .background(Color.white)
+                .background(Color.rtCardAdaptive)
                 .cornerRadius(16)
                 .shadow(color: Color.black.opacity(0.05), radius: 5, x: 0, y: 2)
                 .padding(.horizontal)
@@ -318,7 +318,7 @@ struct ActivityTabView: View {
                 }
             }
             .padding()
-            .background(Color.white)
+            .background(Color.rtCardAdaptive)
             .cornerRadius(16)
             .shadow(color: Color.black.opacity(0.05), radius: 5, x: 0, y: 2)
         }

--- a/RunTail/RunTail/Views/CourseDetailView.swift
+++ b/RunTail/RunTail/Views/CourseDetailView.swift
@@ -33,7 +33,7 @@ struct CourseDetailView: View {
     var body: some View {
         ZStack {
             // 배경색
-            Color.rtBackground
+            Color.rtBackgroundAdaptive
                 .ignoresSafeArea()
             
             VStack(spacing: 0) {

--- a/RunTail/RunTail/Views/CourseSelectionView.swift
+++ b/RunTail/RunTail/Views/CourseSelectionView.swift
@@ -45,7 +45,7 @@ struct CourseSelectionView: View {
                     .fontWeight(.semibold)
                 }
                 .padding()
-                .background(Color.white)
+                .background(Color.rtCardAdaptive)
                 .shadow(color: Color.black.opacity(0.05), radius: 2, x: 0, y: 1)
                 
                 // 코스 목록

--- a/RunTail/RunTail/Views/EnhancedCourseSelectionView.swift
+++ b/RunTail/RunTail/Views/EnhancedCourseSelectionView.swift
@@ -118,7 +118,7 @@ struct EnhancedCourseSelectionView: View {
             .fontWeight(.semibold)
         }
         .padding()
-        .background(Color.white)
+        .background(Color.rtCardAdaptive)
         .shadow(color: Color.black.opacity(0.05), radius: 2, x: 0, y: 1)
     }
     
@@ -170,7 +170,7 @@ struct EnhancedCourseSelectionView: View {
                 .foregroundColor(.gray)
             }
             .padding()
-            .background(Color.white)
+            .background(Color.rtCardAdaptive)
             
             // 지도
             ZStack {

--- a/RunTail/RunTail/Views/ExploreCourseCard.swift
+++ b/RunTail/RunTail/Views/ExploreCourseCard.swift
@@ -101,7 +101,7 @@ struct ExploreCourseCard: View {
                     .foregroundColor(.gray)
             }
             .padding()
-            .background(Color.white)
+            .background(Color.rtCardAdaptive)
             .cornerRadius(20)
             .shadow(color: Color.black.opacity(0.05), radius: 5, x: 0, y: 2)
         }

--- a/RunTail/RunTail/Views/ExploreTabView.swift
+++ b/RunTail/RunTail/Views/ExploreTabView.swift
@@ -196,7 +196,7 @@ struct ExploreTabView: View {
                             }
                             .foregroundColor(sortOption == 2 ? .rtPrimary : .primary)
                         }
-                        .background(Color.white)
+                        .background(Color.rtCardAdaptive)
                         .cornerRadius(16)
                         .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 4)
                         .padding(.horizontal)

--- a/RunTail/RunTail/Views/HomeTabView.swift
+++ b/RunTail/RunTail/Views/HomeTabView.swift
@@ -286,7 +286,7 @@ struct HomeTabView: View {
         } message: {
             Text("방금 완료한 러닝을 코스로 저장합니다.")
         }
-        .background(Color.rtBackground)
+        .background(Color.rtBackgroundAdaptive)
     }
     
     // MARK: - 지도 섹션
@@ -472,7 +472,7 @@ struct HomeTabView: View {
         .padding()
         .background(
             RoundedRectangle(cornerRadius: 20)
-                .fill(Color.white)
+                .fill(Color.rtCardAdaptive)
                 .shadow(color: Color.black.opacity(0.1), radius: 5, x: 0, y: 2)
         )
     }
@@ -492,7 +492,7 @@ struct HomeTabView: View {
                     .font(.system(size: 16, weight: .semibold))
                     .foregroundColor(viewModel.isVoiceGuidanceEnabled ? .rtPrimary : .gray)
                     .frame(width: 36, height: 36)
-                    .background(Color.white)
+                    .background(Color.rtCardAdaptive)
                     .clipShape(Circle())
                     .shadow(color: Color.black.opacity(0.1), radius: 3, x: 0, y: 2)
             }
@@ -509,7 +509,7 @@ struct HomeTabView: View {
                     .font(.system(size: 16, weight: .semibold))
                     .foregroundColor(.rtPrimary)
                     .frame(width: 36, height: 36)
-                    .background(Color.white)
+                    .background(Color.rtCardAdaptive)
                     .clipShape(Circle())
                     .shadow(color: Color.black.opacity(0.1), radius: 3, x: 0, y: 2)
             }
@@ -613,7 +613,7 @@ struct HomeTabView: View {
                                 )
                             }
                         }
-                        .background(Color.white)
+                        .background(Color.rtCardAdaptive)
                         .cornerRadius(20)
                         .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: 5)
                         .transition(.opacity.combined(with: .move(edge: .bottom)))
@@ -867,7 +867,7 @@ struct HomeTabView: View {
             )
         }
         .padding(.vertical, 12)
-        .background(Color.white)
+        .background(Color.rtCardAdaptive)
         .cornerRadius(20)
         .shadow(color: Color.black.opacity(0.05), radius: 8, x: 0, y: 3)
         .padding(.horizontal, 16)
@@ -993,7 +993,7 @@ struct HomeTabView: View {
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 40)
-            .background(Color.white)
+            .background(Color.rtCardAdaptive)
             .cornerRadius(20)
             .shadow(color: Color.black.opacity(0.05), radius: 8, x: 0, y: 3)
             .padding(.horizontal, 16)
@@ -1044,7 +1044,7 @@ struct HomeTabView: View {
                     Spacer()
                 }
                 .padding(16)
-                .background(Color.white)
+                .background(Color.rtCardAdaptive)
                 .cornerRadius(20)
                 .shadow(color: Color.black.opacity(0.06), radius: 8, x: 0, y: 3)
                 .frame(width: 280)
@@ -1094,7 +1094,7 @@ struct HomeTabView: View {
                         .foregroundColor(.gray)
                 }
                 .padding(16)
-                .background(Color.white)
+                .background(Color.rtCardAdaptive)
                 .cornerRadius(20)
                 .shadow(color: Color.black.opacity(0.06), radius: 8, x: 0, y: 3)
                 .frame(width: 260)

--- a/RunTail/RunTail/Views/LoginView.swift
+++ b/RunTail/RunTail/Views/LoginView.swift
@@ -17,7 +17,7 @@ struct LoginView: View {
         NavigationView {
             ZStack {
                 // 배경 색상
-                Color.rtBackground
+                Color.rtBackgroundAdaptive
                     .ignoresSafeArea()
                 
                 // 상단 장식
@@ -47,7 +47,7 @@ struct LoginView: View {
                             .padding(24)
                             .background(
                                 Circle()
-                                    .fill(Color.white)
+                                    .fill(Color.rtCardAdaptive)
                                     .shadow(color: Color.rtPrimary.opacity(0.2), radius: 15, x: 0, y: 5)
                             )
                             .padding(.bottom, 16)
@@ -115,7 +115,7 @@ struct LoginView: View {
                         }
                     }
                     .padding(24)
-                    .background(Color.rtCard)
+                    .background(Color.rtCardAdaptive)
                     .cornerRadius(24)
                     .shadow(color: Color.black.opacity(0.1), radius: 20, x: 0, y: 10)
                     .padding(.horizontal, 24)
@@ -171,7 +171,7 @@ struct TextFieldWithIcon: View {
         .background(
             RoundedRectangle(cornerRadius: 16)
                 .stroke(Color.gray.opacity(0.2), lineWidth: 1)
-                .background(Color.white)
+                .background(Color.rtCardAdaptive)
         )
     }
 }
@@ -198,7 +198,7 @@ struct SecureFieldWithIcon: View {
         .background(
             RoundedRectangle(cornerRadius: 16)
                 .stroke(Color.gray.opacity(0.2), lineWidth: 1)
-                .background(Color.white)
+                .background(Color.rtCardAdaptive)
         )
     }
 }

--- a/RunTail/RunTail/Views/MapView.swift
+++ b/RunTail/RunTail/Views/MapView.swift
@@ -36,7 +36,7 @@ struct MapView: View {
         GeometryReader { geometry in
             ZStack {
                 // 배경색 - 전체 화면 채우기
-                Color.rtBackground
+                Color.rtBackgroundAdaptive
                     .ignoresSafeArea(.all)
                 
                 // 메인 콘텐츠
@@ -250,7 +250,7 @@ struct FloatingTabBar: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .background(Color.rtCard)
+        .background(Color.rtCardAdaptive)
         .cornerRadius(24)
         .shadow(color: Color.black.opacity(0.1), radius: 15, x: 0, y: 5)
         .padding(.horizontal, 16)

--- a/RunTail/RunTail/Views/ProfileTabView.swift
+++ b/RunTail/RunTail/Views/ProfileTabView.swift
@@ -139,7 +139,7 @@ struct ProfileTabView: View {
                             }
                         }
                     }
-                    .background(Color.white)
+                    .background(Color.rtCardAdaptive)
                     .cornerRadius(28)
                     .shadow(color: Color.black.opacity(0.1), radius: 2, x: 0, y: 1)
                     .padding(.horizontal)
@@ -185,7 +185,7 @@ struct ProfileTabView: View {
                             }
                         }
                     }
-                    .background(Color.white)
+                    .background(Color.rtCardAdaptive)
                     .cornerRadius(28)
                     .shadow(color: Color.black.opacity(0.1), radius: 2, x: 0, y: 1)
                     .padding(.horizontal)


### PR DESCRIPTION
## Summary
- define `rtBackgroundAdaptive` and `rtCardAdaptive` colors in `ThemeManager`
- switch background usage to adaptive colors in many views
- update login fields and other controls to respect dark/light mode

## Testing
- `xcodebuild -scheme RunTail -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445e23f39483319f7cdfbb4c7f4712