### PR TITLE
Fix CourseDetail layout

### DIFF
--- a/RunTail/RunTail/Views/CourseDetailView.swift
+++ b/RunTail/RunTail/Views/CourseDetailView.swift
@@ -81,10 +81,10 @@ struct CourseDetailView: View {
                             }
                             .padding(.top, getSafeAreaTop())
                             .padding(.horizontal, 16)
-                            
-                            Spacer()
-                        }
-                
+
+                    Spacer()
+                }
+
                 // 스크롤 가능한 콘텐츠
                 ScrollView {
                     VStack(spacing: 16) {
@@ -113,6 +113,7 @@ struct CourseDetailView: View {
                     .padding(.bottom, 30)
                 }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         }
         .navigationBarHidden(true)
         .onAppear {


### PR DESCRIPTION
## Summary
- ensure the course detail view stretches to device bounds

## Testing
- `xcodebuild test -scheme RunTail -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457d4678f083318ddd999c70ddb359