### PR TITLE
Add default map region fallback

### DIFF
--- a/RunTail/RunTail/Views/CourseDetailView.swift
+++ b/RunTail/RunTail/Views/CourseDetailView.swift
@@ -520,7 +520,15 @@ struct CourseDetailView: View {
     
     // 지도 영역 설정
     private func setupMapRegion() {
-        guard !course.coordinates.isEmpty else { return }
+        guard !course.coordinates.isEmpty else {
+            // Use Seoul city center if coordinates fail to load
+            // This acts as a fallback so `region` always has usable values
+            region = MKCoordinateRegion(
+                center: CLLocationCoordinate2D(latitude: 37.5665, longitude: 126.9780),
+                span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+            )
+            return
+        }
         
         // 좌표의 최소/최대값 찾기
         var minLat = course.coordinates[0].lat


### PR DESCRIPTION
## Summary
- ensure `region` defaults to a usable coordinate when course coordinates are missing

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6845859d4ae08331bb20c1eb2280d97c